### PR TITLE
use captureStackTrace

### DIFF
--- a/l33teral.js
+++ b/l33teral.js
@@ -22,6 +22,18 @@
 
 }(this, function (_, global, undefined) {
 
+  // use native otherwise polyfill
+  var create = Object.create || (function () {
+    var F = function () {};
+    return function (o) {
+      if (arguments.length > 1) { throw new Error('Second argument not supported');}
+      if (o === null) { throw new Error('Cannot set a null [[Prototype]]');}
+      if (typeof o !== 'object') { throw new TypeError('Argument must be an object');}
+      F.prototype = o;
+      return new F();
+    };
+  })();
+
   /**
    * GraphError constructor
    * @param {String} message
@@ -33,11 +45,13 @@
       operation = '';
     }
     Error.call(this, message);
+
     this.name = 'GraphError';
     this.operation = operation;
+    Error.captureStackTrace(this, this.constructor);
   }
 
-  GraphError.prototype = new Error();
+  GraphError.prototype = create(Error.prototype);
   GraphError.prototype.constructor = GraphError;
 
   /**
@@ -415,6 +429,7 @@
       position += 1;
     }
   };
+
 
   return function (literal) {
     return new L33teral(literal);


### PR DESCRIPTION
Cool lib. However, I noticed you were using `new Error` as prototype of your `GraphError`, this is technically the incorrect way to inherit in JS.

Perhaps you were using it to capture the stacktrace, but the stack trace was incorrect. It was capturing at the `new Error` creation. It should be caught at the point where the `GraphError` was created. Also, the error that is shown in a console doesn't mention 'GraphError'.

Here is a fix for that.

If it throws an error now, the stack trace will be properly generated from the `tap` method.

```
# before
Error
    at ../l33teral.js:40:26

# after
GraphError
    at L33teral.tap (../l33teral.js:93:15)
```
