### PR TITLE
fixed probe for undefined attributes

### DIFF
--- a/build/l33teral-latest.js
+++ b/build/l33teral-latest.js
@@ -157,7 +157,7 @@
       lastIndex = properties.length - 1;
 
     while (++index <= lastIndex) {
-      if (isNull(value)) {
+      if (isNull(value) || isUndefined(value)) {
         return false;
       }
       if (!value.hasOwnProperty(properties[index])) {

--- a/l33teral.js
+++ b/l33teral.js
@@ -132,7 +132,7 @@
       lastIndex = properties.length - 1;
 
     while (++index <= lastIndex) {
-      if (isNull(value)) {
+      if (isNull(value) || isUndefined(value)) {
         return false;
       }
       if (!value.hasOwnProperty(properties[index])) {

--- a/test/l33teral.mocha.js
+++ b/test/l33teral.mocha.js
@@ -150,6 +150,9 @@ describe('L33teral', function () {
       var actual = leetMock.probe('occupation.industry.name');
       assert.isFalse(actual);
 
+      var actual = leetMock.probe('occupation.employer.name');
+      assert.isFalse(actual);
+
       done();
     });
   });

--- a/test/mock-object.js
+++ b/test/mock-object.js
@@ -22,7 +22,8 @@ var obj = {
     }
   ],
   "occupation": {
-    "industry": null
+    "industry": null,
+    "employer": undefined
   }
 };
 


### PR DESCRIPTION
while probe handles null attributes, it fails when attributes have a value of `undefined`